### PR TITLE
Pin Actions refs and add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     github-actions:
       patterns:
       - '*'
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
#### Problem
GitHub Actions SHA pinning is enforced, and Dependabot version updates should wait before opening PRs.

#### Solution
Pin remaining workflow action refs to full commit SHAs and set a 7-day Dependabot cooldown for configured update jobs.
