### PR TITLE
Force consistent renovate PR titles regardless of dep grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,12 +6,11 @@
     "config:recommended",
     ":disableDependencyDashboard"
   ],
+  "groupSingleUpdates": true,
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "commitMessageExtra": " ",
-      "commitMessageSuffix": " ",
-      "commitMessageTopic": " ",
       "groupName": "update",
       "matchPackageNames": [
         "*"


### PR DESCRIPTION
#### Problem
Renovate PR titles were inconsistent: a single-dependency update produced `[renovate] weekly`, while a multi-dependency grouped update produced `[renovate] weekly update`.

#### Solution
Add `groupSingleUpdates: true` so the group's title override applies even to lone updates, and drop the now-redundant blank `commitMessageTopic`/`commitMessageSuffix` placeholders. Both cases now render `[renovate] weekly update`.