### PR TITLE
Sort pre-commit hooks and repos alphabetically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,10 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: cb8c523fd4835aba42af70f4cad5568db4df0b6c  # frozen: v0.16.0
   hooks:
-  - id: check-docstring-first
-  - id: debug-statements
-  - id: end-of-file-fixer
-  - id: pretty-format-json
-    args: [--autofix]
-  - id: trailing-whitespace
+  - id: ruff-check
+    args: [--fix]
+  - id: ruff-format
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: 4380fbb73a154b5f5624794c1c78d9719ccc860f  # frozen: v2.16.0
   hooks:
@@ -15,20 +12,6 @@ repos:
     args: [--autofix, --trailing-comma]
   - id: pretty-format-yaml
     args: [--autofix]
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: cb8c523fd4835aba42af70f4cad5568db4df0b6c  # frozen: v0.16.0
-  hooks:
-  - id: ruff-check
-    args: [--fix]
-  - id: ruff-format
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0
-  hooks:
-  - id: mypy
-    language_version: python3.14
-    additional_dependencies:
-    - dijkstar
-    - types-setuptools
 - repo: https://github.com/mxr/mirrors-ty
   rev: d7f08bf6b37691c482773f198ba01539eb331d6a  # frozen: v0.0.63
   hooks:
@@ -40,3 +23,20 @@ repos:
   rev: v0.5.4
   hooks:
   - id: sync-typing-deps
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0
+  hooks:
+  - id: mypy
+    language_version: python3.14
+    additional_dependencies:
+    - dijkstar
+    - types-setuptools
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+  hooks:
+  - id: check-docstring-first
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: pretty-format-json
+    args: [--autofix]
+  - id: trailing-whitespace


### PR DESCRIPTION
#### Problem
Repos and hooks in `.pre-commit-config.yaml` were listed in no particular order, making it harder to scan for a given hook.

#### Solution
Sorted repo blocks by repo url (local repo last) and sorted the hooks within each repo block by hook id. No formatting, spacing, or version changes.